### PR TITLE
Add modprobe quirks config

### DIFF
--- a/rfid.conf
+++ b/rfid.conf
@@ -1,0 +1,1 @@
+options usbhid quirks=0x6688:0x6850:0x0004


### PR DESCRIPTION
Throwing this file in /etc/modprobe.d/ configures the device (203-ID-RW) in quirks mode, preventing udev from owning it

Possible further additions: add the rest of the devices here, add this to README