### PR TITLE
malloc.h not needed and crash macOS make

### DIFF
--- a/ctx-idrw-203.c
+++ b/ctx-idrw-203.c
@@ -136,7 +136,6 @@ Usb payload is 24 bytes large, the unknown layout is most likely T5577/EM4305 st
 #include <stdlib.h> 
 #include <getopt.h>
 #include <unistd.h>
-#include <malloc.h>
 #include <libusb-1.0/libusb.h> 
 
 #define AUTO_FORMAT 0


### PR DESCRIPTION
I tried to compile it on mac. I was able to do it with deleting malloc.h. Tested. Reading and writing are working. My reader is visible under `/dev/tty.usbserial`. Model: `Found device: ID card reader & writer6`, `ID 067b:2303 Prolific Technology, Inc. USB-Serial Controller`